### PR TITLE
Switch to Ctrl+Shift+T to avoid shortcut conflicts

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/prefs.gtkbuilder
+++ b/drop-down-terminal@gs-extensions.zzrough.org/prefs.gtkbuilder
@@ -921,11 +921,12 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">&lt;b&gt;CTRL+T&lt;/b&gt; -  Open a new tab
-&lt;b&gt;ALT+LEFT&lt;/b&gt; - Switch to a previous tab
-&lt;b&gt;ALT+RIGHT&lt;/b&gt; - Switch to a next tab
-&lt;b&gt;Middle mouse button&lt;/b&gt; -  Close tab
-</property>
+                    <property name="label" translatable="yes">
+                        &lt;b&gt;Ctrl+T&lt;/b&gt; -  Open a new tab
+                        &lt;b&gt;Alt+Left&lt;/b&gt; - Switch to the previous tab
+                        &lt;b&gt;Alt+Right&lt;/b&gt; - Switch to the next tab
+                        &lt;b&gt;Middle mouse button&lt;/b&gt; -  Close tab
+                    </property>
                     <property name="use_markup">True</property>
                     <property name="wrap">True</property>
                   </object>

--- a/drop-down-terminal@gs-extensions.zzrough.org/prefs.gtkbuilder
+++ b/drop-down-terminal@gs-extensions.zzrough.org/prefs.gtkbuilder
@@ -922,7 +922,7 @@ Tip: Alt + this key allows to cycle between the windows of an application.&lt;/s
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="label" translatable="yes">
-                        &lt;b&gt;Ctrl+T&lt;/b&gt; -  Open a new tab
+                        &lt;b&gt;Ctrl+Shift+T&lt;/b&gt; -  Open a new tab
                         &lt;b&gt;Alt+Left&lt;/b&gt; - Switch to the previous tab
                         &lt;b&gt;Alt+Right&lt;/b&gt; - Switch to the next tab
                         &lt;b&gt;Middle mouse button&lt;/b&gt; -  Close tab

--- a/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
@@ -173,7 +173,7 @@ const DropDownTerminal = new Lang.Class({
             let [isSymbol, key] = event.get_keyval();
 
 
-            if ((defaultMask & mask) === Gdk.ModifierType.CONTROL_MASK) {
+            if ((defaultMask & mask) === Gdk.ModifierType.CONTROL_MASK + Gdk.ModifierType.SHIFT_MASK) {
               switch(Gdk.keyval_to_upper(key)) {
                 case Gdk.KEY_T:
                   this.addTab('Shell No. ' + this.tabEnumerator++);


### PR DESCRIPTION
I noticed your PR and got a bunch of ideas. A lack of coding experience means I can't quite make it all happen very easily, but here's a start. I changed the shortcut for creating a new tab to Ctrl+Shift+T. This is default shortcut on the gnome-terminal as well, so its what I am used to and I imagine most gnome users would be. I believe the reason this is the default is that certain command line tools use Ctrl+<letter> already. Nano, for example, uses both Ctrl+T and Ctrl+W. It's an extra key, but to avoid conflicts and stay consistent I'd think this makes more sense.

In a separate commit, I changed the text explaining the shortcuts on the tab screen to not be ALL-caps as, quite frankly I see no reason why they should be in caps. As well as prettifying a little indenting.

I wanted to add a shortcut for Ctrl+Shift+W for closing tabs, but haven't managed to get it to work, unfortunately. Motivation for this the same as the create tab, as well as the fact that I think, in particular in a terminal, one should be able to do without the mouse and stay on the keyboard the whole time. Also, some people turn off their middle mouse button because they have a sensitive mouse wheel and some old mouses don't have scroll wheels (that last one is pretty rare though.) 

I hope you find these ideas sensible, and if not I had fun learning more about gnome-extensions. ^^
Have a nice day and Good job.
Balder