### PR TITLE
2 fixes: tab labelling and terminal bell

### DIFF
--- a/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
@@ -141,7 +141,6 @@ const UriHandlingProperties = [
 // terminal class
 const DropDownTerminal = new Lang.Class({
     Name: "DropDownTerminal",
-    tabEnumerator: 1,
     tabs: [],
 
     _init: function() {
@@ -293,8 +292,9 @@ const DropDownTerminal = new Lang.Class({
     },
 
     addTab: function() {
-      let tabName = 'Shell No. ' + this.tabEnumerator++;
       let tab = this._createTerminalTab();
+      tab.number = this.tabs.length ? Math.max(...(this.tabs.map(tab => tab.number))) + 1 : 1;
+      let tabName = 'Shell No. ' + this.tabEnumerator++;
       let eventBox = new Gtk.EventBox();
 
       let label = new Gtk.Label({ halign: Gtk.Align.CENTER, label: tabName, valign: Gtk.Align.CENTER });
@@ -394,6 +394,9 @@ const DropDownTerminal = new Lang.Class({
 
     _createTerminalView: function() {
         let terminal = new Vte.Terminal();
+      
+        let enableBell = this._settings.get_boolean(ENABLE_AUDIBLE_BELL_KEY);
+        terminal.set_audible_bell(enableBell);
 
         terminal.set_can_focus(true);
         terminal.set_allow_bold(true);

--- a/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
+++ b/drop-down-terminal@gs-extensions.zzrough.org/terminal.js
@@ -294,7 +294,7 @@ const DropDownTerminal = new Lang.Class({
     addTab: function() {
       let tab = this._createTerminalTab();
       tab.number = this.tabs.length ? Math.max(...(this.tabs.map(tab => tab.number))) + 1 : 1;
-      let tabName = 'Shell No. ' + this.tabEnumerator++;
+      let tabName = 'Shell No. ' + tab.number;
       let eventBox = new Gtk.EventBox();
 
       let label = new Gtk.Label({ halign: Gtk.Align.CENTER, label: tabName, valign: Gtk.Align.CENTER });


### PR DESCRIPTION
Change 1, tab labelling

previous logic had it that if you created 5 tabs, removed 4, and then created another, it would be labeled as tab 6 instead of tab 2. This change makes it always use the max tab number + 1.

Change 2, terminal bell

There was an issue with the previous logic where new tabs would always have terminal bell enabled, regardless of your settings