### PR TITLE
Avoid crash due to null vs type undefined

### DIFF
--- a/drop-down-terminal-x@bigbn.pro/prefsWindow.js
+++ b/drop-down-terminal-x@bigbn.pro/prefsWindow.js
@@ -275,7 +275,7 @@ var DropDownTerminalSettingsWidget = new GObject.Class({
     let iter = store.append()
 
     let updateShortcutRow = (accel) => {
-      let [key, mods] = (accel !== null) ? Gtk.accelerator_parse(accel) : [0, 0]
+      let [key, mods] = (typeof accel !== "undefined") ? Gtk.accelerator_parse(accel) : [0, 0]
       store.set(iter, [COLUMN_KEY, COLUMN_MODS], [key, mods])
     }
 


### PR DESCRIPTION
It seems like accel may not be defined before and hence a typeof undefined check must be perfomed instead. I had cleared two accelerators, which caused the prefs window to crash on startup. 