### PR TITLE
feat: add gnome 3.36 support

### DIFF
--- a/dist/convenience.js
+++ b/dist/convenience.js
@@ -18,8 +18,8 @@ const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
-const GLIB_VERSION = GLib.MAJOR_VERSION * 10000 + GLib.MINOR_VERSION * 100 + GLib.MICRO_VERSION;
-const GTK_VERSION = Gtk.MAJOR_VERSION * 10000 + Gtk.MINOR_VERSION * 100 + Gtk.MICRO_VERSION;
+var GLIB_VERSION = GLib.MAJOR_VERSION * 10000 + GLib.MINOR_VERSION * 100 + GLib.MICRO_VERSION;
+var GTK_VERSION = Gtk.MAJOR_VERSION * 10000 + Gtk.MINOR_VERSION * 100 + Gtk.MICRO_VERSION;
 
 function getSettings(extensionPath, extensionId) {
   let defaultSource = Gio.SettingsSchemaSource.get_default();

--- a/dist/metadata.json
+++ b/dist/metadata.json
@@ -3,7 +3,7 @@
   "uuid": "drop-down-terminal-x@bigbn.pro",
   "name": "Drop Down Terminal X",
   "description": "Drop down terminal with tabs. Forked from extension \"Drop down terminal\" by zzrough",
-  "shell-version": [ "3.28.0", "3.28.1", "3.28.2", "3.30.0", "3.30.1", "3.30.2", "3.32.0", "3.32.1", "3.32.2", "3.34.0", "3.34.4" ],
+  "shell-version": [ "3.28.0", "3.28.1", "3.28.2", "3.30.0", "3.30.1", "3.30.2", "3.32.0", "3.32.1", "3.32.2", "3.34.0", "3.34.4", "3.36.0" ],
   "url": "https://github.com/bigbn/gs-extensions-drop-down-terminal",
   "gettext-domain": "drop-down-terminal-x"
 }

--- a/dist/terminal.js
+++ b/dist/terminal.js
@@ -1212,7 +1212,7 @@ const DropDownTerminalX = new Lang.Class({
   }
 }); // sets a nice program name and initializes gtk
 
-Gtk.init(null, 0); // sets the setting to prefer a dark theme
+Gtk.init(null); // sets the setting to prefer a dark theme
 
 Gtk.Settings.get_default()['gtk-application-prefer-dark-theme'] = true; // creates the terminal
 

--- a/drop-down-terminal-x@bigbn.pro/convenience.js
+++ b/drop-down-terminal-x@bigbn.pro/convenience.js
@@ -26,11 +26,11 @@ const Gio = imports.gi.Gio
 const GLib = imports.gi.GLib
 const Gtk = imports.gi.Gtk
 
-const GLIB_VERSION = GLib.MAJOR_VERSION * 10000 +
+var GLIB_VERSION = GLib.MAJOR_VERSION * 10000 +
                    GLib.MINOR_VERSION * 100 +
                    GLib.MICRO_VERSION
 
-const GTK_VERSION = Gtk.MAJOR_VERSION * 10000 +
+var GTK_VERSION = Gtk.MAJOR_VERSION * 10000 +
                   Gtk.MINOR_VERSION * 100 +
                   Gtk.MICRO_VERSION
 

--- a/drop-down-terminal-x@bigbn.pro/extension.js
+++ b/drop-down-terminal-x@bigbn.pro/extension.js
@@ -152,12 +152,15 @@ const SouthBorderEffect = new Lang.Class({
     this._width = 1
   },
 
-  vfunc_paint () {
+  vfunc_paint (paintContext) {
+    const framebuffer = paintContext.get_framebuffer();
+    const coglContext = framebuffer.get_context();
     const actor = this.get_actor()
-    const geom = actor.get_allocation_geometry()
-    actor.continue_paint()
-    Cogl.set_source_color(this._color)
-    Cogl.rectangle(0, geom.height, geom.width, geom.height - this._width)
+    const alloc = actor.get_allocation_box()
+    actor.continue_paint(paintContext)
+    let pipeline = new Cogl.Pipeline(coglContext);
+    pipeline.set_color(this._color)
+    framebuffer.draw_rectangle(pipeline, 0, alloc.get_height(), alloc.get_width(), alloc.get_height() - this._width)
   }
 })
 
@@ -253,7 +256,7 @@ const DropDownTerminalXExtension = new Lang.Class({
       Convenience.throttle(100, this, this._updateWindowGeometry) // throttles at 10Hz (it's an "heavy weight" setting)
     })
 
-    this._panelScrollEventHandlerId = Main.panel.actor.connect('scroll-event', Lang.bind(this, this._panelScrolled))
+    this._panelScrollEventHandlerId = Main.panel.connect('scroll-event', Lang.bind(this, this._panelScrolled))
     const busRun = (actionName, ...args) => this._busProxy && this._busProxy[actionName](...args)
 
     this.bindings = [
@@ -433,7 +436,7 @@ const DropDownTerminalXExtension = new Lang.Class({
     global.window_manager.disconnect(this._actorMappedHandlerId)
     Main.layoutManager.disconnect(this._monitorsChangedHandlerId)
     Main.layoutManager.panelBox.disconnect(this._panelAllocationNotificationHandlerId)
-    Main.panel.actor.disconnect(this._panelScrollEventHandlerId)
+    Main.panel.disconnect(this._panelScrollEventHandlerId)
     this._display.disconnect(this._windowCreatedHandlerId)
     this._actorMappedHandlerId = null
     this._monitorsChangedHandlerId = null
@@ -781,7 +784,7 @@ const DropDownTerminalXExtension = new Lang.Class({
     this._childPid = pid
 
     // adds a watch to know when the child process ends
-    GLib.child_watch_add(GLib.PRIORITY_DEFAULT, pid, Lang.bind(this, this._childExited), null)
+    GLib.child_watch_add(GLib.PRIORITY_DEFAULT, pid, Lang.bind(this, this._childExited))
   },
 
   _killChild () {
@@ -945,8 +948,9 @@ const DropDownTerminalXExtension = new Lang.Class({
       return false
     }
 
-    for (const ext in ExtensionUtils.extensions) {
-      if (ANIMATION_CONFLICT_EXTENSION_UUIDS.indexOf(ext.uuid) >= 0 && ext.state == ExtensionSystem.ExtensionState.ENABLED) {
+    for (const extUUID in Main.extensionManager.getUuids()) {
+      const ext = Main.extensionManager.lookup(extUUID)
+      if (ext && ANIMATION_CONFLICT_EXTENSION_UUIDS.indexOf(ext.uuid) >= 0 && ext.state == ExtensionSystem.ExtensionState.ENABLED) {
         return false
       }
     }

--- a/drop-down-terminal-x@bigbn.pro/metadata.json
+++ b/drop-down-terminal-x@bigbn.pro/metadata.json
@@ -3,7 +3,7 @@
   "uuid": "drop-down-terminal-x@bigbn.pro",
   "name": "Drop Down Terminal X",
   "description": "Drop down terminal with tabs. Forked from extension \"Drop down terminal\" by zzrough",
-  "shell-version": [ "3.28.0", "3.28.1", "3.28.2", "3.30.0", "3.30.1", "3.30.2", "3.32.0", "3.32.1", "3.32.2", "3.34.0", "3.34.4" ],
+  "shell-version": [ "3.28.0", "3.28.1", "3.28.2", "3.30.0", "3.30.1", "3.30.2", "3.32.0", "3.32.1", "3.32.2", "3.34.0", "3.34.4", "3.36.0" ],
   "url": "https://github.com/bigbn/gs-extensions-drop-down-terminal",
   "gettext-domain": "drop-down-terminal-x"
 }

--- a/drop-down-terminal-x@bigbn.pro/terminal.js
+++ b/drop-down-terminal-x@bigbn.pro/terminal.js
@@ -1165,7 +1165,7 @@ const DropDownTerminalX = new Lang.Class({
 })
 
 // sets a nice program name and initializes gtk
-Gtk.init(null, 0)
+Gtk.init(null)
 
 // sets the setting to prefer a dark theme
 Gtk.Settings.get_default()['gtk-application-prefer-dark-theme'] = true


### PR DESCRIPTION
Fixes for Gnome Shell 3.36 version. This **might break** in the older versions of Gnome Shell. I couldn't test it. We may need to add a bunch of if/else blocks to add support for older versions or we can just support only the latest Gnome Shell. What do you think @bigbn ?